### PR TITLE
Narrow Callback Parameter Types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -73,7 +73,7 @@ declare module "hot-shots" {
     source_type_name?: string;
   }
 
-  export type StatsCb = (error: Error | undefined, bytes: any) => void;
+  export type StatsCb = (error?: Error, bytes?: number) => void;
 
   export class StatsD {
     constructor(options?: ClientOptions);


### PR DESCRIPTION
# Request

A PR to update the type definitions to slightly narrow the number of possible types the stats callback parameters may be.

When a callback is being added to a stats function (usually inline), it's nice to have more specific types for those callback parameters.

## Background

_I'm a bit of a TypeScript fanatic so I recognize this is a really minor change and I have extra details here that may or may not be necessary!_

After reviewing the **types.d.ts** for all usages of `StatsCb` and then verifying that those functions using `StatsCb`s all ended up using the `_send` method of the client, I've come to the conclusion that this is the most accurate type for `StatsCb`:

```ts
type StatsCb = (error?: Error | null, bytes?: number) => void;
```

However, this is very narrow and most user-written `type`s that try to adhere to the current `type` would break (see Testing) due to the extra possibility that `error` could now be `null`.

My proposed change is:

```ts
type StatsCb = (error?: Error, bytes?: number) => void;
```

which makes the `error` parameter clearly [optional (`?`)](https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters) and also indicates that `bytes` is optional but that, when it is present, it is always a number.

This solution does break one scenario (see Testing, `@ts-expect-error` comment) in which the user has incorrectly typed their own callback function to assume that `bytes` is always present in the call, due to the fact that `any` dissuades TypeScript from further checking its identifier's types.

**If any breaking change is too much work for this**, I would then recommend (and subsequently update the PR) to use this type:

```ts
type StatsCb = (error?: Error, bytes?: number | any) => void;
```

It is the "least different" from the existing `type` but still offers a suggestion as to the type of the `bytes` parameter and is able to take advantage of optional parameters.

If you've made it this far, thank you!

## Testing

I've created [this TypeScript Playground](https://www.typescriptlang.org/play?useUnknownInCatchVariables=true#code/PQKgBADg9gLgpgOxgSwIYBsxwB7IM4oIDmYArnnAE5gDGG6ARqjQNZgBmpCNKUCeYABQwAnhDgATAJRgQwALAAoJTT4FaDAIJgAvEKqUolAFxgAopUPUAPmQQS47ZAkkAaMAxHw8p1AhEyOgB8YADeAL4qajAaAEK6+pZGphZWYLZcDk4uEu6e3qYIpAC2DFSBIRFR-DE0DADCCYIGyeZJNnZZzm4eXnA+diwIUADuCBVhkYqqNRoAIk0tlAD8Ke15fXirYH4BupVTYMDAYHjIxaToqN5gw2BGYABuVCJg6FBQFGCi4njV6nUzIt2r5-BsCjt-BMqoojic8FBinA+HAwCMABZQDjIIikSiSe6kGIwdGo1SWOA8b5ifocB4kuDIaijBCQQwAK0pMH+tQYADFgVZtqkHrYiuh0OD+tsiqVyvtJjyNABxQWtEUdTKObq5XreGUlMqUaFTJRKUBgTEwAC0eCtAggzBYqCIZKgDloePxSHQrzkZsUx2pvyUP1RAGUYNc8PUGAB5Sg45wYNUmNppDL2bU5KUDXYTR5QZASADcoZpYHDiLgkejfIQCaTCBTekEqEoRAGXCGLPcdAlTFYplrMBj8cTRGT6ALRdL5pOzjZzBQNDg7gxiDAABVw2AkR3aWG-tNoqdqyO8PXG5Pm+hh+eo6OrxOp01252+-RBywZAqYfPTnOS5rlRcgqFoehnBIK1bXtU5HwEThuF4VkRmQElvlJJksFwAgoIggcnWPBEkQvZ8mwwQRxUlJQwCEWi6KwdYALAAA9ZYGLo-J+hY9iGOhJRwl-OilBImsEPIm9KOovstCkMtFDEsiGxfW8qMuSU4nk0SHzrFSKPQdSJVk+ptMU3Sn30qTDJk+YzKUiSrKnIzNMBeyLMvJy1Nsuo+Xc0jHOvZyfIYZUzIDC0YLtWAHSdF03Qcdw8FIIhXQIAl-WUQMTiPctxErBDYwAOTgEZU2FdY9WlQpDXlYInlnBSw0rDz6xKsrW3fLsEB7MZP0IocCujYrSpnYsFKDRcIEoZdkFXddSVZHc9yoNLgx4k9ZgcvT2vvAKdtKt8OzwfrGCdX96v-bLAIuK54DIChqH7dB8KiuCCGjDguB4ZA+DRdD0UwxlqBwfBCBIZ7v2I1qEHalzXAYwROKYqwEeutiONhRjuOPIMMf4v9BKkHT9ssuGQs0MygwAAVHa0cHEHh6ZBDhUGQdABDKOgwKBh7wPRVABDDCQgewyGnW+LEMBGVARAEBmuTAAADHGlY8SlUB5lXNlBEQ1aMAzfR2CVRgJdh6QF7lzNJzzyY02TYn88SDpGeGNFMhTtrJ0q3bqOYneUu3jI0MwA8coPXP5MOXd90KzKAA) with potential scenarios in which users may be utilizing the library based on its current types and then comparing that with the suggested change.

<details>
  <summary>Playground Source (Backup)</summary>

  ```ts
  /* potential existing user callback functions (typed) */
  
  const cbA = (error: Error | undefined, bytes: any) => {}
  const cbB = (error: Error | undefined, bytes: number) => {}
  const cbC = (error: Error | undefined, bytes: unknown) => {}
  const cbD = (error?: Error, bytes?: any) => {}
   // simulates no or very loose types
  const cbE = (error: any, bytes: any) => {}
   // someone who figured out the correct types for their own project
  const cbF = (error?: Error | null, bytes?: number) => {}
  const cbG = (error: Error | undefined, bytes?: number) => {}
  const cbH = (error?: unknown, bytes?: unknown) => {}
  
  
  /* hot-shots package code currently */
  
  // types
  type StatsCbOriginal = (error: Error | undefined, bytes: any) => void;
  type SomeStatsFnOriginal = (args: unknown, callback: StatsCbOriginal) => void;
  // in practice, when TS merges types
  const someStatsFnOriginal: SomeStatsFnOriginal = (args, callback)  => {}
  
  // simulate user calling hot-shots stats function with their existing callbacks
  someStatsFnOriginal(null,
    (
      error,
  //  ^?
      bytes
  //  ^?
    ) => {
  })    
  someStatsFnOriginal(null, cbA);
  someStatsFnOriginal(null, cbB);
  someStatsFnOriginal(null, cbC);
  someStatsFnOriginal(null, cbD);
  someStatsFnOriginal(null, cbE);
  someStatsFnOriginal(null, cbF);
  someStatsFnOriginal(null, cbG);
  someStatsFnOriginal(null, cbH);
  
  
  /* hot-shots package code, suggested */
  
  // types
  type StatsCbNew = (error?: Error, bytes?: number) => void;
  type SomeStatsFnNew = (args: unknown, callback: StatsCbNew) => void;
  // in practice, when TS merges types
  const someStatsFnNew: SomeStatsFnNew = (args, callback)  => {}
  
  // simulate user calling hot-shots stats function with their existing callbacks
  someStatsFnNew(null,
    (
      error,
  //  ^?
      bytes
  //  ^?
    ) => {
  })
  someStatsFnNew(null, cbA);
  // @ts-expect-error: fails because the user has typed their callback to always expect `bytes` because `bytes: any` originally allowed for that
  someStatsFnNew(null, cbB);
  someStatsFnNew(null, cbC);
  someStatsFnNew(null, cbD);
  someStatsFnNew(null, cbE);
  someStatsFnNew(null, cbF);
  someStatsFnNew(null, cbG);
  someStatsFnNew(null, cbH);
  ```

</details>